### PR TITLE
chore(nuxt): replace title

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,7 +9,7 @@ export default {
   ** Headers of the page
   */
   head: {
-    title: 'Admin | Lausanne eSports',
+    titleTemplate: '%s | ' process.env.ORG_NAME,
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },


### PR DESCRIPTION
Replace "title" by "titleTemplate" for more flexibility : 

```js
head: {
    titleTemplate: '%s | ' process.env.ORG_NAME,
  },
```